### PR TITLE
Fix tag filter logic

### DIFF
--- a/tests/test_plugin_filter.py
+++ b/tests/test_plugin_filter.py
@@ -1,0 +1,52 @@
+import sys
+import types
+import unittest
+from PyQt6.QtWidgets import QApplication
+
+# Stub QSoundEffect to avoid libpulse dependency during tests
+multimedia_stub = types.ModuleType("PyQt6.QtMultimedia")
+class DummySoundEffect:
+    def __init__(self, *args, **kwargs):
+        pass
+multimedia_stub.QSoundEffect = DummySoundEffect
+sys.modules.setdefault("PyQt6.QtMultimedia", multimedia_stub)
+
+from widgets.pluginstoregrid import PluginStoreGridWidget
+
+class TestTagFilter(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.app = QApplication.instance() or QApplication(sys.argv)
+
+    def setUp(self):
+        # Prevent network loading of plugins in __init__
+        self._original_load = PluginStoreGridWidget.load_plugins
+        PluginStoreGridWidget.load_plugins = lambda self: None
+        self.widget = PluginStoreGridWidget()
+        PluginStoreGridWidget.load_plugins = self._original_load
+
+        self.captured = None
+        def capture(plugins):
+            self.captured = plugins
+        self.widget.display_plugins = capture
+
+        self.widget.all_plugins = [
+            {"name": "Alpha", "tags": ["audio"]},
+            {"name": "Beta", "tags": ["video"]},
+        ]
+
+        self.widget.tag_filter.clear()
+        self.widget.tag_filter.addItems(["Alle tags", "audio", "video"])
+
+    def test_filter_audio_tag(self):
+        self.widget.tag_filter.setCurrentText("audio")
+        self.widget.filter_plugins()
+        self.assertEqual(len(self.captured), 1)
+        self.assertEqual(self.captured[0]["name"], "Alpha")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.app.quit()
+
+if __name__ == "__main__":
+    unittest.main()

--- a/widgets/pluginstoregrid.py
+++ b/widgets/pluginstoregrid.py
@@ -69,7 +69,7 @@ class PluginStoreGridWidget(QWidget):
         filtered = []
         for plugin in self.all_plugins:
             name_match = term in plugin['name'].lower()
-            tag_match = selected_tag == "Alle tags"
+            tag_match = selected_tag == "Alle tags" or selected_tag in plugin.get("tags", [])
             if name_match and tag_match:
                 filtered.append(plugin)
 


### PR DESCRIPTION
## Summary
- fix tag filter check in PluginStoreGridWidget
- add unit test for the new tag filter logic

## Testing
- `python -m unittest -v tests/test_plugin_filter.py`

------
https://chatgpt.com/codex/tasks/task_e_6878df23eb7c8322930e596821c5f81d