### PR TITLE
Enhance settings and plugin helpers

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -193,6 +193,8 @@ class HauswerkCore(QMainWindow):
 if __name__ == "__main__":
     Logger.log("🚀 Start Hauswerk applicatie")
     app = QApplication([])
+    s = SettingsManager.instance()
+    StyleManager.apply_theme(app, s.get("theme", "light"), s.get("font_size", 12), s.get("accent_color", "#44cc88"))
     window = HauswerkCore()
     window.show()
     app.exec()

--- a/core/logger.py
+++ b/core/logger.py
@@ -1,4 +1,6 @@
 class Logger:
+    """Simple GUI logger that buffers messages until a widget is attached."""
+
     _log_widget = None
     _buffer = []
     _enabled = True

--- a/core/settings.py
+++ b/core/settings.py
@@ -3,7 +3,7 @@ import json
 from PyQt6.QtCore import QObject, pyqtSignal
 from PyQt6.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QComboBox, QSpinBox,
-    QPushButton, QDialogButtonBox, QFileDialog, QApplication
+    QPushButton, QDialogButtonBox, QFileDialog, QApplication, QCheckBox
 )
 
 class SettingsManager(QObject):
@@ -18,7 +18,9 @@ class SettingsManager(QObject):
             "theme": "light",
             "max_layers": 6,
             "presets_dir": os.path.expanduser("~/.megatool_presets"),
-            "font_size": 12
+            "font_size": 12,
+            "accent_color": "#44cc88",
+            "compact_mode": False
         }
         self.load()
 
@@ -105,6 +107,13 @@ class SettingsDialog(QDialog):
         hlayout2b.addWidget(self.fontsize_spin)
         layout.addLayout(hlayout2b)
 
+        # Accentkleur
+        hlayout_color = QHBoxLayout()
+        hlayout_color.addWidget(QLabel("Accentkleur:"))
+        self.accent_edit = QLineEdit()
+        hlayout_color.addWidget(self.accent_edit)
+        layout.addLayout(hlayout_color)
+
         # Max collage-lagen
         hlayout3 = QHBoxLayout()
         hlayout3.addWidget(QLabel("Max. collage-lagen:"))
@@ -123,6 +132,9 @@ class SettingsDialog(QDialog):
         hlayout4.addWidget(browse_btn2)
         layout.addLayout(hlayout4)
 
+        self.compact_check = QCheckBox("Compacte layout")
+        layout.addWidget(self.compact_check)
+
         self.buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
         self.buttons.accepted.connect(self.accept)
         self.buttons.rejected.connect(self.reject)
@@ -134,6 +146,7 @@ class SettingsDialog(QDialog):
         # Live preview op wissel thema of fontgrootte
         self.theme_combo.currentTextChanged.connect(self._preview_theme)
         self.fontsize_spin.valueChanged.connect(self._preview_theme)
+        self.accent_edit.textChanged.connect(self._preview_theme)
 
     def _browse_folder(self):
         folder = QFileDialog.getExistingDirectory(self, "Kies outputmap")
@@ -157,13 +170,16 @@ class SettingsDialog(QDialog):
         self.fontsize_spin.setValue(int(s.get("font_size", 12)))
         self.max_layers_spin.setValue(int(s.get("max_layers", 6)))
         self.presets_dir_edit.setText(s.get("presets_dir", os.path.expanduser("~/.megatool_presets")))
+        self.accent_edit.setText(s.get("accent_color", "#44cc88"))
+        self.compact_check.setChecked(bool(s.get("compact_mode", False)))
 
     def _preview_theme(self):
         theme = self.theme_combo.currentText()
         font_size = self.fontsize_spin.value()
+        accent = self.accent_edit.text()
         app = QApplication.instance()
         from core.style import StyleManager
-        StyleManager.apply_theme(app, theme, font_size)
+        StyleManager.apply_theme(app, theme, font_size, accent)
 
     def accept(self):
         self.settings.set("output_dir", self.outdir_edit.text())
@@ -171,4 +187,6 @@ class SettingsDialog(QDialog):
         self.settings.set("max_layers", self.max_layers_spin.value())
         self.settings.set("presets_dir", self.presets_dir_edit.text())
         self.settings.set("font_size", self.fontsize_spin.value())
+        self.settings.set("accent_color", self.accent_edit.text())
+        self.settings.set("compact_mode", self.compact_check.isChecked())
         super().accept()

--- a/core/show_splash.py
+++ b/core/show_splash.py
@@ -1,11 +1,14 @@
 
+"""Utility to display a fading splash screen."""
+
 from PyQt6.QtCore import QTimer, QPropertyAnimation, QEasingCurve, Qt
-from PyQt6.QtGui import QPixmap
+from PyQt6.QtGui import QPixmap, QPainter
 from PyQt6.QtSvg import QSvgRenderer
 from PyQt6.QtWidgets import QApplication, QSplashScreen
 import os
 
-def show_splash(theme="light", parent_window=None, duration=1500):
+def show_splash(theme: str = "light", parent_window=None, duration: int = 1500):
+    """Display the Hauswerk splash screen with fade in/out animations."""
     splash = None
     base_path = os.path.dirname(__file__)
     # search for resources one directory up from the core package
@@ -22,8 +25,9 @@ def show_splash(theme="light", parent_window=None, duration=1500):
         renderer = QSvgRenderer(svg_path)
         pixmap = QPixmap(500, 300)
         pixmap.fill(Qt.GlobalColor.transparent)
-        painter = QPixmap(pixmap)
+        painter = QPainter(pixmap)
         renderer.render(painter)
+        painter.end()
         splash_pix = pixmap
     else:
         png_path = os.path.join(res_path, f"splash_{theme}.png")

--- a/core/style.py
+++ b/core/style.py
@@ -3,12 +3,13 @@ from core.settings import SettingsManager
 
 class StyleManager:
     @staticmethod
-    def apply_theme(app, theme_name, font_size=None):
+    def apply_theme(app, theme_name, font_size=None, accent=None):
         qss_file = os.path.join(SettingsManager.styles_dir(), f"{theme_name}.qss")
         if os.path.exists(qss_file):
             with open(qss_file, "r") as f:
                 qss = f.read()
-            accent = SettingsManager.instance().get("accent_color", "#44cc88")
+            if accent is None:
+                accent = SettingsManager.instance().get("accent_color", "#44cc88")
             qss = qss.replace("@accent", accent)
             if font_size:
                 qss += f"\nQWidget {{ font-size: %dpx; }}\n" % int(font_size)

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,0 +1,9 @@
+import re
+
+
+def slugify(text: str) -> str:
+    """Generate a lowercase slug with hyphens from the given text."""
+    base = "".join(c for c in text.lower() if c.isalnum() or c in " -_")
+    base = re.sub(r"[^a-z0-9_-]", "", base.strip())
+    slug = "-".join(base.split())
+    return slug[:20] or "plugin"

--- a/widgets/hpb.py
+++ b/widgets/hpb.py
@@ -11,6 +11,7 @@ import requests
 from pathlib import Path
 import tempfile
 import shutil
+from core.utils import slugify
 
 SUPABASE_URL = "https://izlcnpelomuuwxijnnuh.supabase.co"
 SUPABASE_KEY = os.environ.get("SUPABASE_KEY")
@@ -141,7 +142,7 @@ class PluginUploadTab(QWidget):
             QMessageBox.warning(self, "Invoer ontbreekt", "Naam en beschrijving zijn verplicht.")
             return
 
-        slug = name.lower().replace(" ", "-")
+        slug = slugify(name)
         if slug in self.existing_slugs:
             QMessageBox.warning(self, "Bestaat al", f"De plugin '{slug}' bestaat al in de index.")
             return

--- a/widgets/plugin_generator/plugin_generator_helpers.py
+++ b/widgets/plugin_generator/plugin_generator_helpers.py
@@ -4,11 +4,11 @@ import json
 import os
 import zipfile
 import re
+from core.utils import slugify
 
 def generate_slug(text):
-    base = "".join(c for c in text.lower() if c.isalnum() or c in " -_")
-    base = re.sub(r'[^a-z0-9_-]', '', base.strip())
-    return "-".join(base.split())[:20] or "plugin"
+    """Backward compatible wrapper around :func:`slugify`."""
+    return slugify(text)
 
 def write_metadata_file(plugin_dir: Path, slug: str, classname: str, metadata: dict, log_func):
     metadata.update({

--- a/widgets/plugin_generator/pluginwizard.py
+++ b/widgets/plugin_generator/pluginwizard.py
@@ -17,6 +17,7 @@ import zipfile
 from core.settings import SettingsManager
 from .plugin_template_fallback import generate_fallback_main_py
 from .ollama_integration import is_ollama_installed, run_ollama_prompt
+from core.utils import slugify
 
 class MetadataFields(QGroupBox):
     def __init__(self):
@@ -133,7 +134,7 @@ class PluginGeneratorWidget(QWidget):
             return
 
         full_prompt = f"Template: {template}. {prompt}"
-        slug = self._generate_slug(prompt)
+        slug = slugify(prompt)
         if not slug:
             QMessageBox.warning(self, "Fout", "Slug kon niet worden gegenereerd.")
             return
@@ -215,6 +216,5 @@ class PluginGeneratorWidget(QWidget):
         dlg.exec()
 
     def _generate_slug(self, text):
-        base = "".join(c for c in text.lower() if c.isalnum() or c in " -_")
-        base = re.sub(r'[^a-z0-9_-]', '', base.strip())
-        return "-".join(base.split())[:20]
+        """Deprecated helper kept for backward compatibility."""
+        return slugify(text)

--- a/widgets/standard_tool_layout.py
+++ b/widgets/standard_tool_layout.py
@@ -1,5 +1,11 @@
 # widgets/standard_tool_layout.py
 
+"""Reusable container for tool plugins.
+
+This widget arranges common rows like input/output selectors, option
+controls, action buttons and log widgets in a consistent vertical layout.
+"""
+
 from PyQt6.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout
 
 class StandardToolLayout(QWidget):


### PR DESCRIPTION
## Summary
- add `slugify` helper for consistent plugin slugs
- fix QPainter usage in `show_splash`
- support accent color and compact mode in settings
- expose theme preview updates
- apply theme on startup
- document standard tool layout and logger

## Testing
- `QT_QPA_PLATFORM=offscreen PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878e240905083229dbb7e5a9a8b4912